### PR TITLE
Port to electron

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1,0 +1,30 @@
+const http = require('http')
+const child_process = require('child_process')
+const electron = require('electron')
+const {app, BrowserWindow} = electron
+
+let mainWindow
+
+function startFlaskServer() {
+  child_process.exec("source frontend_env/bin/activate && python3 main.py", function(error, stdout, stderr){
+        console.log(stdout);
+        console.log(stderr);
+        if (error) {
+            throw error;
+        }
+    });
+  setTimeout(createWindow, 5000)
+}
+
+function createWindow () {
+  mainWindow = new BrowserWindow({width: 1200, height: 900})
+  mainWindow.loadURL("http://127.0.0.1:5000/welcome/connect")
+
+  mainWindow.on('closed', function () {
+    mainWindow = null
+    app.quit();
+  })
+}
+
+app.on('ready', startFlaskServer)
+app.on('ready', createWindow)

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from flask import Flask, request, render_template
 import flask
-from labsuite.protocol import Protocol
+from opentrons_sdk.protocol import Protocol
 from flask_socketio import SocketIO, emit
 import logging
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ot-one-desktop-app",
+  "productName": "OT One App",
+  "version": "2.0.0",
+  "description": "This is the frontend component the OpenTrons OT.One. It's a browser user interface served from the OT.One",
+  "main": "main.js",
+  "author": {
+    "name": "engineering@opentrons.com",
+    "email": "engineering@opentrons.com"
+  },
+  "license": "Apache"
+}

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,3 +1,5 @@
 Flask==0.10.1
 requests==2.9.1
 Flask_SocketIO
+logging
+gevent


### PR DESCRIPTION
This is a PR to add an Electron `main.js` and `package.json`. I was having issues with turning `main.py` into an executable so I just used `virtualenv`. To set this up, run `virtualenv -p python3 frontend_env` in the `app` folder. After creating this virtual environment, you will need to install the normal dependencies (`pip install -r requirements.txt`) and any other dependencies (I'm pretty sure Katie has listed a couple dependencies not in the requirements.txt?). Then, running `electron .` will launch the Electron app.

This also assumes you have the opentrons_sdk module locally - an easy way to do so is to run `pip install -e /path/to/opentrons_sdk/`.