### PR TITLE
Upload

### DIFF
--- a/app/renderer/src/components/Upload.vue
+++ b/app/renderer/src/components/Upload.vue
@@ -1,9 +1,62 @@
 <template>
-  <div>TEST TEST TEST</div>
+  <div>
+    <section>
+      <h2 class="title center">Upload a Protocol</h2>
+      <div class="instructions center">
+        Upload a valid JSON or Python Protocol. Errors will display below.
+      </div>
+      <div class="step step-upload">
+        <input id="uploadFile" disabled="disabled">{{fileName}}</input>
+        <div class="fileUpload">
+          <span>Upload</span>
+          <input @change="onFileChange" id="uploadBtn" type="file" class="upload" />
+        </div>
+      </div>
+      <nav>
+        <router-link to="/" class="prev">Prev</router-link>
+        <router-link to="#info" class="help">?</router-link>
+        <router-link to="/" class="next">Next</router-link>
+      </nav>
+    </section>
+    <div id="info" class="infoModal">
+      <div> <a href="#close" title="Close" class="close">X</a>
+        <h2>Title</h2>
+        <p>
+          Images would go here along with explanation text.
+        </p>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
   export default {
-    name: 'Upload'
+    name: 'Upload',
+    computed: {
+      fileName () {
+        return this.$store.state.current_protocol_name
+      }
+    },
+    methods: {
+      onFileChange(e) {
+        var files = e.target.files || e.dataTransfer.files
+        if (!files.length)
+          return;
+        var reader = new FileReader();
+        reader.fileName = files[0].name
+        reader.onload = this.uploadProtocol
+        reader.readAsText(files[0], 'UTF-8');
+      },
+      uploadProtocol(event) {
+        var target = event.target
+        this.$store.dispatch("uploadProtocol", target)
+      }
+    }
   }
 </script>
+
+<style>
+  .center {
+    text-align: center;
+  }
+</style>

--- a/app/renderer/src/store.js
+++ b/app/renderer/src/store.js
@@ -7,6 +7,7 @@ Vue.use(Vuex)
 const state = {
     is_connected: false,
     port: null,
+    current_protocol_name: "No File Selected"
 }
 
 
@@ -15,6 +16,9 @@ const mutations = {
         state.is_connected = payload.is_connected
         state.port = payload.port
     },
+    UPDATE_CURRENT_PROTOCOL (state, payload) {
+      state.current_protocol_name = payload.current_protocol_name
+    }
 }
 
 const actions = {
@@ -45,6 +49,16 @@ const actions = {
             }, (response) => {
                 console.log('Failed to communicate to backend server. Failed to connect', response)
             })
+    },
+    uploadProtocol ({commit}, target) {
+      Vue.http
+        .post('http://localhost:5000/upload', {file: target.result})
+        .then((response) => {
+          console.log(response)
+          commit('UPDATE_CURRENT_PROTOCOL', {'current_protocol_name': target.fileName})
+        }, (response) => {
+          console.log('failed to upload', response)
+        })
     }
 }
 

--- a/server/main.py
+++ b/server/main.py
@@ -6,7 +6,7 @@ import threading
 sys.path.insert(0, os.path.abspath('..'))
 
 import flask
-from flask import Flask, render_template
+from flask import Flask, render_template, request
 from flask_socketio import SocketIO
 
 from opentrons_sdk.robot import Robot
@@ -33,18 +33,18 @@ robot = Robot.get_instance()
 def welcome():
     return render_template("index.html")
 
+@app.route("/upload", methods=["POST"])
+def upload():
+    print(request.data)
+    # this should eventually process the protocol for errors
+    return request.data
+
 
 @app.route('/dist/<path:filename>')
 def script_loader(filename):
     root = get_frozen_root() or app.root_path
     scripts_root_path = os.path.join(root, 'templates', 'dist')
     return flask.send_from_directory(scripts_root_path, filename)
-
-
-# welcome route for uploading protocol
-@app.route("/upload/<path:path>")
-def upload(path):
-    return render_template("upload.html")
 
 
 @app.route("/robot/serial/list")


### PR DESCRIPTION
This PR adds an Upload component that lets users select a file with their OS specific file navigator. Selecting a file then sends a POST request to 127.0.0.1:5000/upload, which will eventually lint for errors, syntax, etc. It also triggers a Vuex update to store the current protocol's filename globally.